### PR TITLE
Prepare site for TLS (remove hardcoded protocols)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  
+
   <meta property="og:type" content="website">
 	<meta property="og:url" content="http://koalacoder.com">
 	<meta property="og:title" content="Koalacoder: Laura Barluzzi's portfolio">
@@ -13,18 +13,18 @@
 	<meta property="og:image:width" content="1200">
 	<meta property="og:image:height" content="630">
   <meta property="fb:app_id" content="611622352362359">
-  
+
   <title>KoalaCoder</title>
-  <link href="https://fonts.googleapis.com/css?family=Lobster|Shadows+Into+Light" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"/>
-  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/fullPage.js/2.8.9/jquery.fullPage.min.css">  
-  <link rel="stylesheet" href='https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css'>
-  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/ekko-lightbox/5.1.1/ekko-lightbox.min.css">
-  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap3-dialog/1.34.7/css/bootstrap-dialog.min.css">
-  <link rel="shortcut icon" href="http://koalacoder.com/favicon.ico" type="image/x-icon">
-  <link rel="icon" href="http://koalacoder.com/favicon.ico" type="image/x-icon">
+  <link href="//fonts.googleapis.com/css?family=Lobster|Shadows+Into+Light" rel="stylesheet">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"/>
+  <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/fullPage.js/2.8.9/jquery.fullPage.min.css">
+  <link rel="stylesheet" href='//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css'>
+  <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/ekko-lightbox/5.1.1/ekko-lightbox.min.css">
+  <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/bootstrap3-dialog/1.34.7/css/bootstrap-dialog.min.css">
+  <link rel="shortcut icon" href="//koalacoder.com/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="//koalacoder.com/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="style.css">
-   
+
 </head>
 
 <body>
@@ -33,15 +33,15 @@
     <div class="container-fluid">
 
       <div class="navbar-header">
-        
+
         <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
           <i class="fa fa-bars"></i>
         </button>
         <a class="navbar-brand" href="#about-contact">
           <img class="img-responsive profile-navbar" alt="Laura Barluzzi profile picture" src="images/profile.png"/></a>
-        <a href="#about-contact" class="navbar-text band-text"> Laura Koalacoder</a>    
+        <a href="#about-contact" class="navbar-text band-text"> Laura Koalacoder</a>
       </div>
-      
+
       <div class="collapse navbar-collapse">
         <ul class="nav navbar-nav navbar-right" id="myNavbar">
           <li data-menuanchor="home-page" class="active"><a href="#home-page">Home</a></li>
@@ -63,13 +63,13 @@
               the Koalacoder portfolio &mdash; a mix of tech, creativity and social justice
           </div>
           <ul class="socialMedia">
-            <li><a href="https://github.com/laura-barluzzi" target="_blank" 
+            <li><a href="//github.com/laura-barluzzi" target="_blank"
                    data-toggle="tooltip" title="see my GitHub"><button class="btn btn-primary btn-circle btn-lg"><i class="fa fa-fw fa-github"></i></button></a></li>
-            <li><a href="https://www.linkedin.com/in/laura-barluzzi-4602015b" target="_blank"
+            <li><a href="//www.linkedin.com/in/laura-barluzzi-4602015b" target="_blank"
                    data-toggle="tooltip" title="see my Linkedin"><button class="btn btn-primary btn-circle btn-lg"><i class="fa fa-fw fa-linkedin"></i></button></a></li>
-            <li><a href="https://www.facebook.com/search/top/?q=Laura+Barluzzi&init=public" target="_blank"
+            <li><a href="//www.facebook.com/search/top/?q=Laura+Barluzzi&init=public" target="_blank"
                    data-toggle="tooltip" title="see my Facebook"><button class="btn btn-primary btn-circle btn-lg"><i class="fa fa-facebook" aria-hidden="true"></i></button></a></li>
-            <li><a href="https://www.freecodecamp.com/laura-barluzzi" target="_blank"
+            <li><a href="//www.freecodecamp.com/laura-barluzzi" target="_blank"
                    data-toggle="tooltip" title="see my FreeCodeCamp"><button class="btn btn-primary btn-circle btn-lg"><i class="fa fa-fw fa-free-code-camp"></i></button></a></li>
           </ul>
 
@@ -79,40 +79,40 @@
 
     <div class="section" id="coding1">
       <div class="container-fluid">
-          
+
         <div class="intro-box">
           <div class="title">Coding</div>
-          <div class="subtitle">After obtaining a programmer diploma and a front end certificate, today I code in Python, Javascript, HTML, and CSS. I'm currently deepening my skills and self-learning at www.freecodecamp.com &mdash; See my current projects on <a href="https://github.com/laura-barluzzi?tab=repositories" target="_blank" data-toggle="tooltip" title="see my GitHub">github</a>. 
+          <div class="subtitle">After obtaining a programmer diploma and a front end certificate, today I code in Python, Javascript, HTML, and CSS. I'm currently deepening my skills and self-learning at www.freecodecamp.com &mdash; See my current projects on <a href="//github.com/laura-barluzzi?tab=repositories" target="_blank" data-toggle="tooltip" title="see my GitHub">github</a>.
           </div>
         </div>
-          
+
         <div class="box-display">
-           
-          <a href="https://github.com/laura-barluzzi/Learn-Python-hard-way" target="_blank"
+
+          <a href="//github.com/laura-barluzzi/Learn-Python-hard-way" target="_blank"
              data-toggle="tooltip" title="see GitHub repository">
              <div  class="thumbnail">
             <img class="img-dimention" data-src="images/coding1.png"/>
             Python exercises
             </div>
           </a>
-          
-          <a href="http://codepen.io/Laura-Barluzzi/full/ygvzyE/" target="_blank"
+
+          <a href="//codepen.io/Laura-Barluzzi/full/ygvzyE/" target="_blank"
              data-toggle="tooltip" title="see on Codepen">
             <div  class="thumbnail">
             <img class="img-dimention" data-src="images/coding2.png"/>
             Simon Game
             </div>
           </a>
-          
-          <a href="http://codepen.io/Laura-Barluzzi/full/VPrqML/" target="_blank"
+
+          <a href="//codepen.io/Laura-Barluzzi/full/VPrqML/" target="_blank"
              data-toggle="tooltip" title="see on Codepen">
              <div  class="thumbnail">
             <img class="img-dimention" data-src="images/coding3.png"/>
             Tic Tac Toe game
             </div>
           </a>
- 
-          <a href="http://codepen.io/Laura-Barluzzi/full/GNVowN/" target="_blank"
+
+          <a href="//codepen.io/Laura-Barluzzi/full/GNVowN/" target="_blank"
              data-toggle="tooltip" title="see on Codepen">
              <div  class="thumbnail">
             <img class="img-dimention" data-src="images/coding4.png"/>
@@ -120,94 +120,94 @@
             </div>
           </a>
 
-          <a href="http://codepen.io/Laura-Barluzzi/full/pRemdd/" target="_blank"
+          <a href="//codepen.io/Laura-Barluzzi/full/pRemdd/" target="_blank"
              data-toggle="tooltip" title="see on Codepen">
              <div  class="thumbnail">
             <img class="img-dimention" data-src="images/coding5.jpg"/>
             Pomodoro clock
             </div>
-          </a> 
-          
-          <a href="http://codepen.io/Laura-Barluzzi/full/OWXJwy/" target="_blank"
+          </a>
+
+          <a href="//codepen.io/Laura-Barluzzi/full/OWXJwy/" target="_blank"
              data-toggle="tooltip" title="see on Codepen">
              <div  class="thumbnail">
             <img class="img-dimention" data-src="images/coding6.jpg"/>
             Calculator
             </div>
-          </a> 
+          </a>
 
-          <a href="http://codepen.io/Laura-Barluzzi/full/GrKbNx/" target="_blank"
+          <a href="//codepen.io/Laura-Barluzzi/full/GrKbNx/" target="_blank"
              data-toggle="tooltip" title="see on Codepen">
              <div  class="thumbnail">
             <img class="img-dimention" data-src="images/coding7.png"/>
             Twitch TV stream
             </div>
           </a>
-                  
+
         </div>
       </div>
     </div>
 
     <div class="section" id="art2">
       <div class="container-fluid">
-      
+
         <div class="intro-box">
           <div class="title">Art &amp; Design </div>
-          <div class="subtitle">Since I was a child I performed well in creative tasks. 
-          I mainly take photos and I make photo-edits, posters and logos by using Adobe 
+          <div class="subtitle">Since I was a child I performed well in creative tasks.
+          I mainly take photos and I make photo-edits, posters and logos by using Adobe
           Photoshop, InDesign, Gimp and InkScape.
           </div>
         </div>
-        
+
         <div class="box-display">
-        
-            <a href="images/larger/art1.jpg" data-toggle="lightbox" data-title="Climb to Success" 
+
+            <a href="images/larger/art1.jpg" data-toggle="lightbox" data-title="Climb to Success"
                data-footer="2010, hand-drawing &amp; Photoshop" data-toggle="tooltip" title="enlarge me">
               <img class="img-thumbnail img-responsive" data-src="images/art1.jpg"></a>
-            
-            <a href="images/larger/art2.jpg" data-toggle="lightbox" data-title="With and For Love" 
+
+            <a href="images/larger/art2.jpg" data-toggle="lightbox" data-title="With and For Love"
                data-footer="2009, hand-drawing &amp; Photoshop" data-toggle="tooltip" title="enlarge me">
               <img class="img-thumbnail img-responsive" data-src="images/art2.jpg"></a>
-            
-            <a href="images/larger/art3.jpg" data-toggle="lightbox" data-title="Shared Suffering" 
+
+            <a href="images/larger/art3.jpg" data-toggle="lightbox" data-title="Shared Suffering"
                data-footer="2010, hand-drawing &amp; Photoshop" data-toggle="tooltip" title="enlarge me">
               <img class="img-thumbnail img-responsive" data-src="images/art3.jpg"></a>
-            
-            <a href="images/art4.jpg" data-toggle="lightbox" data-title="Lokole project logo" 
+
+            <a href="images/art4.jpg" data-toggle="lightbox" data-title="Lokole project logo"
                data-footer="2016, InkScape &amp; Gimp" data-toggle="tooltip" title="enlarge me">
               <img class="img-thumbnail img-responsive" data-src="images/art4.jpg"></a>
-            
-            <a href="images/larger/art5.jpg" data-toggle="lightbox" data-title="Praying for the Best" 
+
+            <a href="images/larger/art5.jpg" data-toggle="lightbox" data-title="Praying for the Best"
                data-footer="2007, hand-drawing &amp; Photoshop" data-toggle="tooltip" title="enlarge me">
               <img class="img-thumbnail img-responsive" data-src="images/art5.jpg"></a>
-            
-            <a href="images/larger/art6.jpg" data-toggle="lightbox" data-title="Family" 
+
+            <a href="images/larger/art6.jpg" data-toggle="lightbox" data-title="Family"
                data-footer="2015, Collage &amp; Photoshop" data-toggle="tooltip" title="enlarge me">
               <img class="img-thumbnail img-responsive" data-src="images/art6.jpg"></a>
-            
-            <a href="images/larger/art7.jpg" data-toggle="lightbox" data-title="The Love of Koala & Mouse" 
+
+            <a href="images/larger/art7.jpg" data-toggle="lightbox" data-title="The Love of Koala & Mouse"
                data-footer="2016, Acrylic on canvas" data-toggle="tooltip" title="enlarge me">
               <img class="img-thumbnail img-responsive" data-src="images/art7.jpg"></a>
 
-        </div>  
+        </div>
       </div>
     </div>
 
     <div class="section" id="NGOs3">
       <div class="container-fluid">
-          
-        <div class="intro-box"> 
+
+        <div class="intro-box">
            <div class="title">NGOs &amp; international development</div>
-           <div class="subtitle">In the last 10-years I have gathered experiences at NGOs that 
-           promote human rights and sustainable development &mdash; see my 
+           <div class="subtitle">In the last 10-years I have gathered experiences at NGOs that
+           promote human rights and sustainable development &mdash; see my
            <a href="images/larger/resume.pdf" target="_blank"
-              data-toggle="tooltip" title="open my resume">CV</a>. I also obtained a BSc 
-           in International Studies and a 
+              data-toggle="tooltip" title="open my resume">CV</a>. I also obtained a BSc
+           in International Studies and a
            <a href="images/larger/MSc.jpg" target="_blank" data-toggle="tooltip" title="see my master degree">
            MSc in International Development</a>.
            </div>
         </div>
-        
+
         <div class="box-display">
 
           <a class="thumbnail" id="job1" rel="modal" data-toggle="tooltip" title="see more information">
@@ -225,12 +225,12 @@
             Project coordinator
           </a>
 
-          <a href="http://bccic.ca/wp-content/uploads/2016/02/BCCIC_FinalTechnicalReport_IDRCSmallCitiesandTowns.pdf" class="thumbnail" target="_blank" data-toggle="tooltip" title="see more information">
+          <a href="//bccic.ca/wp-content/uploads/2016/02/BCCIC_FinalTechnicalReport_IDRCSmallCitiesandTowns.pdf" class="thumbnail" target="_blank" data-toggle="tooltip" title="see more information">
             <img class="img-dimention" data-src="images/ngo5.jpg">
             Co-author report
           </a>
 
-          <a href="http://bccic.ca/wp-content/uploads/2016/06/Keeping-Track-Measuring-Progress-Toward-the-UN-Sustainable-Development-Goals-24.06.2016.pdf" class="thumbnail" target="_blank" data-toggle="tooltip" title="see more information">
+          <a href="//bccic.ca/wp-content/uploads/2016/06/Keeping-Track-Measuring-Progress-Toward-the-UN-Sustainable-Development-Goals-24.06.2016.pdf" class="thumbnail" target="_blank" data-toggle="tooltip" title="see more information">
             <img class="img-dimention" data-src="images/ngo4.jpg">
             Co-author &amp; editor
           </a>
@@ -258,22 +258,22 @@
                   <span class="skype"><i class="fa fa-skype" aria-hidden="true"></i>: labarluzzi</span></div>
               </div>
 
-              <div class="half-box" id="contact-form"> 
+              <div class="half-box" id="contact-form">
                 <div class="title">Contact me</div>
                 <form action="#">
                   <div class="container-fluid">
                     <div class="row">
-                    
+
                       <div class="col-xs-6 col-md-6" style="padding-left: 0; padding-right: 5px">
                         <label for="fname">First Name:</br></label>
                         <input type="text" id="fname" placeholder="your name"></input>
                       </div>
-                      
+
                       <div class="col-xs-6 col-md-6" style="padding-left: 5px; padding-right: 0">
                         <label for="lname">Last Name:</br></label>
                         <input type="text" id="lname" placeholder="your surname"></input>
                       </div>
-                      
+
                     </div>
                   </div>
 
@@ -285,17 +285,17 @@
                   <div style="text-align: center"><input type="submit" class="btn btn-primary" value="Send"></div>
                 </form>
               </div>
-              
+
       </div>
     </div>
   </div>
 
 
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/fullPage.js/2.8.9/jquery.fullPage.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap3-dialog/1.34.7/js/bootstrap-dialog.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ekko-lightbox/5.1.1/ekko-lightbox.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+  <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/fullPage.js/2.8.9/jquery.fullPage.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/bootstrap3-dialog/1.34.7/js/bootstrap-dialog.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/ekko-lightbox/5.1.1/ekko-lightbox.min.js"></script>
   <script src="script.js"></script>
 
 </body>

--- a/script.js
+++ b/script.js
@@ -31,71 +31,71 @@ function setUpFullpage(screenSize) {
 }
 
 
-$(document).ready(function() { 
-  
-  var heightScreen = $(window).height(); 
+$(document).ready(function() {
+
+  var heightScreen = $(window).height();
   var widthScreen = $(window).width();
   console.log(heightScreen + " width = " + widthScreen);
   setBackgroundColor(heightScreen);
-  setUpFullpage(checkDevice(heightScreen, widthScreen));      
+  setUpFullpage(checkDevice(heightScreen, widthScreen));
 
 //So the Mobile Nav Hides When a Link is Clicked
   $(".navbar-nav li a").click(function(event) {
     $(".navbar-collapse").collapse('hide');
   });
-  
+
   $(document).on('click', '[data-toggle="lightbox"]', function(event) {
     event.preventDefault();
     $(this).ekkoLightbox();
   });
-  
-  
+
+
 /* list of objects with job information */
   var job1 = {title: "Chief Operation Officer & Fundraiser",
-              employer: '<p><b>Employer: </b><a href="http://ascoderu.ca" target="_blank">Ascoderu</a></p>',
+              employer: '<p><b>Employer: </b><a href="//ascoderu.ca" target="_blank">Ascoderu</a></p>',
               description: "<p><b>Description: </b>I am supporting the Lokole project of Ascoderu by establishing key-partnerships, producing promotional materials, designing the new website and managing the workload of a team of three people. Lokole aims to bring free emails in rural DRC in 2017.</p>",
               reference: "<p><b>Reference: </b>Nzola Swasisa CEO, info@ascoderu.ca</p>"};
-   $("#job1").data("job", job1); 
-   
+   $("#job1").data("job", job1);
+
    var job2 = {title: "Office & Regional Activist Assistant",
-              employer: '<p><b>Employer: </b><a href="https://www.amnesty.ca/" target="_blank">Amnesty International</a></p>',
+              employer: '<p><b>Employer: </b><a href="//www.amnesty.ca/" target="_blank">Amnesty International</a></p>',
               description: '<p><b>Description: </b>For months I helped with the organization of events such as the Just Film Festival and the “Focus on Syria” event screening refugees’ documentaries. Further, for 2 weeks I was hired as Office Assistant and I run the office while coordinating high-school volunteers.</p>',
               reference: "<p><b>Reference: </b>Don Wright, DWright@amnesty.ca</p>"};
    $("#job2").data("job", job2);
-   
+
    var job3 = {title: "Research & Project Coordinator",
-              employer: '<p><b>Employer: </b><a href="https://www.bccic.ca/" target="_blank">British Columbia Council for International Cooperation (BCCIC)</a></p>',
+              employer: '<p><b>Employer: </b><a href="//www.bccic.ca/" target="_blank">British Columbia Council for International Cooperation (BCCIC)</a></p>',
               description: "<p><b>Description: </b>I have conducted research and coordinated projects. I supervised six UBC students during their internship and I presented at the CASID conference on 1st June 2016 on behalf of the BCCIC. The focus of my research space from international cooperation in small cities to the SDGs. I co-authored and co-edited two reports.</p>",
               reference: "<p><b>Reference: </b>Mike Simpson, mike@bccic.ca</p>"};
    $("#job3").data("job", job3);
-              
+
    var job6 = {title: "General Assistant",
-              employer: '<p><b>Employer: </b><a href="http://www.samarcandascs.it/" target="_blank">Samarcanda FairTrade Shop</a></p>',
+              employer: '<p><b>Employer: </b><a href="//www.samarcandascs.it/" target="_blank">Samarcanda FairTrade Shop</a></p>',
               description: "<p><b>Description: </b>Samarcanda is a fairtrade social co-operative and while volunteering there I learned about global supply chain, worker’s right infringement and related projects. My role covered cash book keeping, project promotion and other general assistant tasks.</p>",
               reference: "<p><b>Reference: </b>Antonella Capraro, samarcanda.belluno@livecom.it</p>"};
-   $("#job6").data("job", job6);      
-              
-              
+   $("#job6").data("job", job6);
+
+
   $("a[rel='modal']").click(function(event){
     var clicked = $(this);
     var job = clicked.data("job");
 
     var $title = $('<div></div>').css("font-size", "30px").html(job.title);
     var $text = $('<div></div>').addClass("subtitle").html(job.employer + job.description + job.reference);
-    
+
     BootstrapDialog.show({
       title: $title,
       message: $text,
     });
   });
-  
+
   $(function () {
     $('[data-toggle="tooltip"]').tooltip()
   });
-  
-  
+
+
   $("#contact-form").hide();
-  
+
   /*
   $("#myNavbar a").click(function(event){
     var $a=$(event.target);
@@ -104,11 +104,11 @@ $(document).ready(function() {
     var $liActive = $ul.find("li.active");
     $liActive.removeClass("active");
     $li.addClass("active");
-    
+
     var target = $a.attr("href").substr(1);
     console.log(target);
     $.fn.fullpage.moveTo(target,0);
-    
+
     event.preventDefault();
   });
   */

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Lobster);
+@import url(//fonts.googleapis.com/css?family=Lobster);
 
 body {
   padding-top: 70px;
@@ -14,7 +14,7 @@ body {
 
 .fa-bars {
   color: white;
-} 
+}
 
 .navbar {
   height: auto;
@@ -50,7 +50,7 @@ ul {
 .navbar-inverse .navbar-nav > .active > a:hover,
 .navbar-inverse .navbar-nav > .active > a:focus {
   color: #3385ff;
-  background: #222;  
+  background: #222;
 }
 
 /* fullpage sections background*/
@@ -83,7 +83,7 @@ ul {
   display: -webkit-flex;
   display: flex;
   flex-direction: column;
-  justify-content: center; 
+  justify-content: center;
   align-items: center;
   background-color:rgba(242,	242,	242, 0.6);
   border-radius: 1%;
@@ -128,7 +128,7 @@ ul {
   margin-right: 0px;
   margin-left: 0px;
   }
-  
+
 .big-box > .half-box {
   display: -webkit-box;
   display: -moz-box;
@@ -221,8 +221,8 @@ ul > li {
   border-radius: 50%;
   border-style: solid;
   border-width: 3px;
-  border-color: white; 
-  margin-bottom: 20px;  
+  border-color: white;
+  margin-bottom: 20px;
 }
 
 @media (max-width: 500px) {
@@ -234,11 +234,11 @@ ul > li {
     margin: 0 auto;
     margin-bottom: 10px;
     }
-    
+
   .subtitle .skype {
     display: block;
   }
-    
+
   .after-slash:after {
     content: "" !important;
   }
@@ -255,7 +255,7 @@ ul > li {
 
 .top-space {
   margin-top: 20px;
-}  
+}
 
  input[type=text] {
   width: 100%;
@@ -274,7 +274,7 @@ textarea {
   box-sizing: border-box;
   border: 2px solid #ccc;
   border-radius: 4px;
-  background-color: #f8f8f8; 
+  background-color: #f8f8f8;
   font-size: 16px;
   resize: none;
 }


### PR DESCRIPTION
A site served over HTTPS can't make requests to resources hosted on HTTP for security reasons. This site currently hard-codes the protocol for a number of non-secure resources, i.e., there are `http://` links in the page, which means that the page can't render if served over HTTPS.

Instead of hard-coding the protocol for links, we can simply specify `href="//` instead of `href="http://` or `href="https://`. This will create links that use the same protocol as what the site is being served via. So if the site is being served over http, the links will be http. If it's being served over https, the links will be https. Given that most sites out there support both https and http anyways, making the links respect the current page protocol is usually a very safe change. As such, this pull request implements the dynamic protocol links.

Also: fix trailing spaces.